### PR TITLE
Sometimes PNG image has more than one IDAT chunk.

### DIFF
--- a/png.h
+++ b/png.h
@@ -18,5 +18,8 @@ int php_zopfli_is_invalid_signature(unsigned char *in);
 uint32_t php_zopfli_read_uint32(unsigned char *in, uint32_t *ipos);
 void php_zopfli_write_uint32(unsigned char *out, uint32_t *opos, uint32_t data);
 uLongf php_zopfli_calc_inflate_buf_size(unsigned char *in, uint32_t *ipos);
+void php_zopfli_write_idat_chunks(unsigned char *out, uint32_t *opos, 
+                                  unsigned char *idat_chunks, size_t idat_chunks_size,
+                                  size_t idat_chunk_size);
 
 #endif


### PR DESCRIPTION
Currently zopfli_png_recompress makes recompressed PNG image have single IDAT chunk.

After apply this patch, 
- If a PNG image has more than one IDAT chunk, zopfli_png_recompress makes a recompressed PNG image have multiple IDAT chunks.
- zopfli_png_recompress sets the compressed(with zopfli) IDAT chunk size the length of the first IDAT chunk.

This patch is for the streaming.
