### PR TITLE
Enable container-based infrastructure on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - 5.6
   - 7.0
 
+sudo: false
+
 before_script:
   - phpize
   - ./configure


### PR DESCRIPTION
To make the build faster.

Reference:
https://docs.travis-ci.com/user/workers/container-based-infrastructure/