### PR TITLE
PHP 8 compat, remove PHP 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: php
-dist: precise
+dist: trusty
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
+  - master
+
+matrix:
+  allow_failures:
+    - php: master
 
 env:
   - REPORT_EXIT_STATUS=1 NO_INTERACTION=1

--- a/php_zopfli.h
+++ b/php_zopfli.h
@@ -11,22 +11,4 @@
 extern zend_module_entry zopfli_module_entry;
 #define phpext_zopfli_ptr &zopfli_module_entry
 
-#ifdef PHP_WIN32
-#    define PHP_ZOPFLI_API __declspec(dllexport)
-#elif defined(__GNUC__) && __GNUC__ >= 4
-#    define PHP_ZOPFLI_API __attribute__ ((visibility("default")))
-#else
-#    define PHP_ZOPFLI_API
-#endif
-
-#ifdef ZTS
-#    include "TSRM.h"
-#endif
-
-#ifdef ZTS
-#    define ZOPFLI_G(v) TSRMG(zopfli_globals_id, zend_zopfli_globals *, v)
-#else
-#    define ZOPFLI_G(v) (zopfli_globals.v)
-#endif
-
 #endif  /* PHP_ZOPFLI_H */

--- a/png.h
+++ b/png.h
@@ -2,6 +2,8 @@
 #ifndef PHP_ZOPFLI_PNG_H
 #define PHP_ZOPFLI_PNG_H
 
+#ifdef HAVE_ZLIB_H
+
 #include <zlib.h>
 
 #define ZOPFLI_PNG_SIGNATURE_SIZE  8
@@ -20,5 +22,7 @@ void php_zopfli_write_uint32(unsigned char *out, uint32_t *opos, uint32_t data);
 uLongf php_zopfli_calc_inflate_buf_size(unsigned char *in, uint32_t *ipos);
 void php_zopfli_write_idat_chunks(unsigned char *out, uint32_t *opos,
                                   unsigned char *idat_chunks, size_t idat_chunks_size, size_t idat_chunk_size);
+
+#endif /* HAVE_ZLIB_H */
 
 #endif

--- a/tests/zopfli_png_recompress.phpt
+++ b/tests/zopfli_png_recompress.phpt
@@ -1,11 +1,16 @@
 --TEST--
 Test zopfli_png_recompress() function
+--SKIPIF--
+<?php
+if (!extension_loaded("zopfli")) {
+    die('skip The zopfli extension is not loaded');
+}
+if (!function_exists("zopfli_png_recompress")) {
+    die('skip The zopfli extension is built without zlib support');
+}
+?>
 --FILE--
 <?php
-if (!extension_loaded('zopfli')) {
-    dl('zopfli.' . PHP_SHLIB_SUFFIX);
-}
-
 $origin_file = dirname(__FILE__) . '/php.png';
 $recompress_file = dirname(__FILE__) . '/php-recomp.png';
 


### PR DESCRIPTION
Feel free to close if PHP 5 support is still desired, of course.

- Use FAST_ZPP where available
- I made `zopfli_png_recompress` not exist when zlib isn't enabled - this way you can skip the test when the function is not defined (it was just failing before)