### PR TITLE
Add PHP 7.4 to TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
   - master
 
 matrix:

--- a/tests/004.phpt
+++ b/tests/004.phpt
@@ -30,7 +30,7 @@ var_dump(zopfli_uncompress("", 9));
 
 var_dump(zopfli_uncompress($data1));
 var_dump(zopfli_uncompress($data2));
-$data2{4} = 0;
+$data2[4] = 0;
 var_dump(zopfli_uncompress($data2));
 
 echo "Done\n";

--- a/tests/005.phpt
+++ b/tests/005.phpt
@@ -31,7 +31,7 @@ var_dump(zopfli_inflate("asdf", 100));
 
 var_dump(zopfli_inflate($data1));
 var_dump(zopfli_inflate($data2));
-$data2{4} = 0;
+$data2[4] = 0;
 var_dump(zopfli_inflate($data2));
 
 echo "Done\n";


### PR DESCRIPTION
* Fix error caused by deprecation of curly brace access for strings [[0]]

[0]: https://wiki.php.net/rfc/deprecate_curly_braces_array_access